### PR TITLE
Added support for swade

### DIFF
--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -1,6 +1,10 @@
 import CONSTANTS from './constants.js';
 
 export async function createDependentRegionForTemplate(templateDoc, specifiedBehaviors) {
+    if (!templateDoc.object.shape) {
+        //If we have no shape, we need to refresh it to create and configuring the shape correctly
+        templateDoc.object._refreshShape();
+    }
     let origShape = templateDoc.object.shape ?? templateDoc.object._computeShape();
     let points = origShape.points ?? origShape.toPolygon().points;
     let shape = {

--- a/scripts/hooks.js
+++ b/scripts/hooks.js
@@ -22,7 +22,7 @@ export default function registerHooks() {
     Hooks.on('createMeasuredTemplate', async (templateDoc) => {
         if (!game.user.isGM) return;
         let systemId = game.system.id;
-        if (['dnd5e', 'pf2e'].includes(systemId)) {
+        if (['dnd5e', 'pf2e', 'swade'].includes(systemId)) {
             let flagDocument;
             let actorUuid;
             let activityUuid;
@@ -41,6 +41,10 @@ export default function registerHooks() {
                 actorUuid = originUuid?.split('.').toSpliced(-2).join('.');
             } else if (systemId === 'pf2e') {
                 originUuid = templateDoc.getFlag('pf2e', 'origin.uuid');
+                flagDocument = await fromUuid(originUuid);
+                actorUuid = flagDocument?.actor?.uuid;
+            } else if (systemId === 'swade') {
+                originUuid = templateDoc.getFlag('swade', 'origin');
                 flagDocument = await fromUuid(originUuid);
                 actorUuid = flagDocument?.actor?.uuid;
             }

--- a/scripts/module.js
+++ b/scripts/module.js
@@ -1,12 +1,13 @@
 import registerHooks from './hooks.js';
 import { registerSettings } from './settings.js';
-import { registerSheetOverrides, registerDnd5eSheetOverrides, registerPF2eSheetOverrides } from './sheet-overrides.js';
+import { registerSheetOverrides, registerDnd5eSheetOverrides, registerPF2eSheetOverrides, registerSwadeSheetOverrides } from './sheet-overrides.js';
 
 Hooks.once('init', async function() {
     registerHooks();
     registerSheetOverrides();
     if (game.system.id === 'dnd5e') registerDnd5eSheetOverrides();
     if (game.system.id === 'pf2e') registerPF2eSheetOverrides();
+    if (game.system.id === 'swade') registerSwadeSheetOverrides();
     registerSettings();
 });
 

--- a/scripts/sheet-overrides.js
+++ b/scripts/sheet-overrides.js
@@ -13,6 +13,9 @@ export function registerDnd5eSheetOverrides() {
 export function registerPF2eSheetOverrides() {
     Hooks.on('renderItemSheetPF2e', patchPF2eItemSheet);
 }
+export function registerSwadeSheetOverrides() {
+    Hooks.on('renderItemSheet', patchSwadeItemSheet);
+}
 
 export function registerSheetOverrides() {
     Hooks.on('renderTileConfig', patchTileConfig);
@@ -131,6 +134,55 @@ function patchTidyItemSheet(app, element, { item }) {
     html.find('#configureRegionButton')[0].onclick = () => {openRegionConfig(item)};
 }
 
+// Swade
+function patchSwadeItemSheet(app, html, { item }) {
+    if (!game.user.isGM && !getSetting(CONSTANTS.SETTINGS.SHOW_OPTIONS_TO_NON_GMS)) return;
+    // Check if any of the template types are enabled
+    let templateSection = html.find('div[class="templates"]');
+    let inputs = templateSection.find("input");
+    let hasTemplate = false;
+    for (let input of inputs) {
+        if (input.checked) {
+            hasTemplate = true;
+            break;
+        }
+    }
+    //If we have a template, insert the attach region controls
+    if (hasTemplate) {
+        let fullFlag = getFullFlagPath(CONSTANTS.FLAGS.ATTACH_REGION_TO_TEMPLATE);
+        let attachRegionToTemplate = foundry.utils.getProperty(item, fullFlag) ?? false;
+        let attachCheckbox = foundry.applications.fields.createCheckboxInput({
+            name: getFullFlagPath(CONSTANTS.FLAGS.ATTACH_REGION_TO_TEMPLATE),
+            value: attachRegionToTemplate
+        });
+        attachCheckbox._onClick = async (event) => {
+            event.preventDefault();
+            await item.update({ [fullFlag]: !event.target.checked });
+        };
+        let attachCheckboxGroup = foundry.applications.fields.createFormGroup({
+            label: 'REGION-ATTACHER.AttachRegionToTemplate',
+            localize: true,
+            input: attachCheckbox
+        });
+        $(attachCheckboxGroup).insertAfter(templateSection);
+        //If attach is enabled, show the config button
+        if (attachRegionToTemplate && game.user.isGM) {
+            let configureButton = $(`
+                <button id="configureRegionButton" style="flex: 1;"'}>
+                    <i class="fa fa-gear"></i>
+                    ${game.i18n.localize('REGION-ATTACHER.ConfigureRegion')}
+                </button>
+            `)[0];
+            configureButton.onclick = () => { openRegionConfig(app.item, app.activity); };
+            let configureButtonGroup = foundry.applications.fields.createFormGroup({
+                label: 'REGION-ATTACHER.RegionAttacher',
+                localize: true,
+                input: configureButton
+            });
+            $(configureButtonGroup).insertAfter(attachCheckboxGroup);
+        }
+    }
+}
 function getRegionTabHtml() {
     return `
         <a class="item" data-tab="region">


### PR DESCRIPTION
Hi, I use swade and wanted to have support for this module in the abilities themselves like you have in dnd and pf so I went ahead and implemented it myself. I've done my best to match your coding style. Let me know if there's anything you'd like me to change.

I tested my changes with dnd5e as well just to make sure nothing broke. One thing I'll call out is the addition of `_refreshShape` when creating the region. In swade, it's necessary that we do this because inside that function Foundry also initializes the ray which is used by swade's version of `_computeShape`.

One other thing to mention is that this is dependent on a small change I submitted to swade (it's already been merged) which won't be available until the next swade version is released (4.4). I'm not sure exactly when that will be but it will be before v13. I've tested without my change and nothing breaks but it obviously doesn't work either. I'll leave it up to you if you want to merge this now or wait until that releases.