### PR TITLE
Enhance region attachment functionality in PF2e item sheets

### DIFF
--- a/scripts/sheet-overrides.js
+++ b/scripts/sheet-overrides.js
@@ -34,7 +34,7 @@ function getAttachRegionHtml(document, isTidy=false) {
                     <input id="attachRegionCheckbox" type="checkbox" name="${getFullFlagPath(CONSTANTS.FLAGS.ATTACH_REGION_TO_TEMPLATE)}" ${shouldDisable ? 'disabled' : ''} ${attachRegionToTemplate ? 'checked' : ''} ${game.system.id === 'pf2e' ? 'style="margin-top: -5px;"' : ''}>
                     ${document instanceof MeasuredTemplateDocument ? game.i18n.localize('REGION-ATTACHER.AttachRegion') : game.i18n.localize('REGION-ATTACHER.AttachRegionToTemplate')}
                 </label>
-                <button id="configureRegionButton" style="flex: 1;" ${(attachRegionToTemplate && isGM && !shouldDisable) ? '' : 'disabled'} ${isGM ? '' : 'data-tooltip="REGION-ATTACHER.NonGMConfigureTooltip"'}>
+                <button id="configureRegionButton" style="flex: 1; white-space: nowrap;" ${(attachRegionToTemplate && isGM && !shouldDisable) ? '' : 'disabled'} ${isGM ? '' : 'data-tooltip="REGION-ATTACHER.NonGMConfigureTooltip"'}>
                     <i class="fa fa-gear"></i>
                     ${game.i18n.localize('REGION-ATTACHER.ConfigureRegion')}
                 </button>
@@ -102,16 +102,19 @@ function patchActivitySheet(app, element) {
 // PF2e
 function patchPF2eItemSheet(app, html, { item }) {
     if (!game.user.isGM && !getSetting(CONSTANTS.SETTINGS.SHOW_OPTIONS_TO_NON_GMS)) return;
-    // For spells with area
-    let elementBefore = html.find('select[name="system.area.type"]')?.[0];
-    // Otherwise, for items with has inline template
-    if ( !elementBefore?.value?.length && item.system?.description?.value?.includes("@Template")) {
-        elementBefore = html.find('input[name="system.deathNote"]')?.[0];
+
+    // For items with an inline @Template in the description
+    if (item.system?.description?.value?.includes("@Template")) {
+        const elementFound = html.find('fieldset.publication')?.[0];
+        if (!elementFound) return;
+        $(getAttachRegionHtml(item)).insertBefore(elementFound);
+    } else {
+        // For spells, put it next to the Area input
+        const elementFound = html.find('select[name="system.area.type"]')?.[0]?.parentNode?.parentNode;
+        if (!elementFound) return;
+        $(getAttachRegionHtml(item)).insertAfter(elementFound);
     }
-    if (!elementBefore?.value?.length) return;
-    let targetElem = elementBefore.parentNode.parentNode;
-    if (!targetElem) return;
-    $(getAttachRegionHtml(item)).insertAfter(targetElem);
+
     html.find("#configureRegionButton")[0].onclick = () => {
         openRegionConfig(item);
     };


### PR DESCRIPTION
 * Will now attach to any Item sheet type that has `@Template` in description instead of just sheets with Death Notes (e.g. equipment, feats, etc)
 * Moved to just above Publication fieldset which is common to all Item sheets.
 * Left regionHTML for spells as is, since that still made sense to be next to Area.